### PR TITLE
Check if record exists or show 404 - remove `optional` and refactor examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,21 +631,18 @@ $model = Flight::where('legs', '>', 3)->firstOr(function () {
 ```
 
 ### Check if record exists or show 404
-Don't use find() and then check if the record exists. Use findOrFail() or optional().
+Don't use find() and then check if the record exists. Use findOrFail().
 ```php
 $product = Product::find($id);
-if ($product) {
-    $product->update($productDataArray);
+if (!$product) {
+    abort(404);
 }
+$product->update($productDataArray);
 ```
 Shorter way
 ```php
 $product = Product::findOrFail($id); // shows 404 if not found
 $product->update($productDataArray);
-```
-Even shorter
-```php
-optional(Product::find($id))->update($productDataArray);
 ```
 
 ## Models Relations


### PR DESCRIPTION
Check if record exists or show 404 - remove `optional` and refactor examples


1. Refactor the first example to throw 404 error when model is not found.
2. Remove 3rd example (`optional`) as it doesn't throw 404 error and it doesn't perform real `update`. In some cases, it can lead to misunderstanding.

Now all the examples have the same behavior - throw 404 error or update the model.