### PR TITLE
How to prevent “property of non-object” error - withDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ $post->author->name ?? ''
 // But you can do it on Eloquent relationship level:
 // this relation will return an empty App\Author model if no author is attached to the post
 public function author() {
-    return $this->belongsTo('App\Author')->withDefaults();
+    return $this->belongsTo('App\Author')->withDefault();
 }
 // or
 public function author() {


### PR DESCRIPTION
According to the docs (https://laravel.com/docs/8.x/eloquent-relationships#default-models), the method should be `withDefault`, not `withDefaults`.