### PR TITLE
Fix typo in db models and eloquent

### DIFF
--- a/db-models-and-eloquent.md
+++ b/db-models-and-eloquent.md
@@ -161,7 +161,7 @@ Natural language
 
 Search for `something`
 ```php
-Comment::whereFulltext(['title', 'descriptiong'], 'something')->get();
+Comment::whereFulltext(['title', 'description'], 'something')->get();
 ```
 
 Natural language with Query Expansion


### PR DESCRIPTION
Fix a typo in `descriptiong` word, in the `db-models-and-eloquent.md` file.